### PR TITLE
Update toolshed test helper for shed/ loc subdir; fix black formatting

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -170,7 +170,6 @@ class InstallRepositoryManager:
         session.add(tool_shed_repository)
         session.commit()
 
-        is_data_manager = "data_manager" in irmm_metadata_dict
         if "sample_files" in irmm_metadata_dict:
             sample_files = irmm_metadata_dict.get("sample_files", [])
             tool_index_sample_files = stdtm.get_tool_index_sample_files(sample_files)
@@ -191,17 +190,13 @@ class InstallRepositoryManager:
             # so they're separated from admin-configured loc files at tool_data_path root.
             shed_loc_dir = os.path.join(self.app.config.tool_data_path, "shed")
             os.makedirs(shed_loc_dir, exist_ok=True)
-            tool_util.copy_sample_files(
-                shed_loc_dir, tool_index_sample_files, tool_path=tool_path
-            )
+            tool_util.copy_sample_files(shed_loc_dir, tool_index_sample_files, tool_path=tool_path)
             sample_files_copied = [str(s) for s in tool_index_sample_files]
             repository_tools_tups = irmm.get_repository_tools_tups()
             if repository_tools_tups:
-                if is_data_manager:
-                    # Only Data Manager repos register data tables on install.
-                    repository_tools_tups = stdtm.handle_missing_data_table_entry(
-                        relative_install_dir, tool_path, repository_tools_tups
-                    )
+                repository_tools_tups = stdtm.handle_missing_data_table_entry(
+                    relative_install_dir, tool_path, repository_tools_tups
+                )
                 # Handle missing index files for tool parameters that are dynamically generated select lists.
                 repository_tools_tups, sample_files_copied = tool_util.handle_missing_index_file(
                     self.app, tool_path, sample_files, repository_tools_tups, sample_files_copied

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -169,15 +169,19 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         attributing them to the installing repository. 99% of .loc.sample files are empty/comments,
         in which case this is a no-op.
 
-        Skipped for non-tabular table types (e.g. ``RefgenieToolDataTable``) whose
-        ``parse_file_fields`` is not designed to read a ``.loc.sample``.
+        Rows that reference ``${__HERE__}`` are dropped with a warning: the shared loc file lives
+        under ``tool_data_path/shed/``, so a preserved ``${__HERE__}`` would resolve to the wrong
+        directory at read time.
+
+        Caller must gate on ``isinstance(existing_table, TabularToolDataTable)`` — non-tabular
+        table types have a different ``parse_file_fields`` contract.
         """
-        if getattr(existing_table, "type_key", "tabular") != "tabular":
-            return
         attribution = (
             f"Added by {tool_shed_repository.owner}/{tool_shed_repository.name}"
             f"@{tool_shed_repository.installed_changeset_revision}"
         )
+        here_sentinel = "${__HERE__}"
+        table_name = elem.get("name") or ""
         for file_elem in elem.findall("file"):
             shared_path = file_elem.get("path")
             if not shared_path:
@@ -186,28 +190,47 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             source_loc_sample = loc_basename_to_source.get(basename)
             if not source_loc_sample or not os.path.exists(source_loc_sample):
                 continue
-            # Keep `${__HERE__}` literal so the appended rows match the shared loc's existing format.
-            new_rows = existing_table.parse_file_fields(source_loc_sample, here="${__HERE__}")
-            if new_rows:
-                existing_table.append_entries_with_attribution(new_rows, attribution)
+            # Pass the sentinel through unsubstituted so we can detect rows that used HERE.
+            parsed_rows = existing_table.parse_file_fields(source_loc_sample, here=here_sentinel)
+            kept_rows = []
+            for row in parsed_rows:
+                if any(here_sentinel in field for field in row):
+                    log.warning(
+                        "Skipping row in '%s' that references ${__HERE__}: shared loc file '%s' "
+                        "would resolve it to the wrong directory (table '%s', repo '%s/%s').",
+                        source_loc_sample,
+                        shared_path,
+                        table_name,
+                        tool_shed_repository.owner,
+                        tool_shed_repository.name,
+                    )
+                    continue
+                kept_rows.append(row)
+            if kept_rows:
+                existing_table.append_entries_with_attribution(kept_rows, attribution)
 
-    def _shed_config_has_matching_entry(self, table_name: str, elem: Element) -> bool:
-        """Return True if ``shed_tool_data_table_config`` already has a ``<table>`` with the same
-        ``name`` and identical set of ``<file path>`` entries as ``elem``.
-
-        Used to avoid writing duplicate ``<table>`` entries for tables that have already been
-        registered by a prior install. The shed config remains the persistent source of the
-        shared loc file's association with the data table name — on reload, ``merge_tool_data_table``
-        re-applies the filename info to the in-memory table.
-        """
+    def _load_shed_config_tree(self):
+        """Parse ``shed_tool_data_table_config`` once for dedup checks. Returns ``None`` if the
+        file doesn't exist or can't be read; callers treat that as "nothing to dedup against"."""
         config = self.app.config.shed_tool_data_table_config
         if not config or not os.path.exists(config):
-            return False
+            return None
         try:
             tree, _ = xml_util.parse_xml(config)
         except OSError as e:
             log.warning("Could not read shed_tool_data_table_config '%s' for dedup check: %s", config, e)
-            return False
+            return None
+        return tree
+
+    @staticmethod
+    def _tree_has_matching_entry(tree, table_name: str, elem: Element) -> bool:
+        """Return True if ``tree`` (parsed ``shed_tool_data_table_config``) already has a
+        ``<table>`` with ``name == table_name`` and identical set of ``<file path>`` entries
+        as ``elem``. Used to avoid writing duplicate ``<table>`` entries for tables that have
+        already been registered by a prior install. The shed config remains the persistent
+        source of the shared loc file's association with the data table name — on reload,
+        ``merge_tool_data_table`` re-applies the filename info to the in-memory table.
+        """
         if tree is None:
             return False
         elem_paths = {fe.get("path") for fe in elem.findall("file") if fe.get("path")}
@@ -279,6 +302,8 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
                 TOOL_DATA_TABLE_FILE_SAMPLE_NAME,
             )
         registered_tables = self.app.tool_data_tables.data_tables
+        # Parse the shed config once for dedup checks instead of re-reading it per elem.
+        shed_config_tree = self._load_shed_config_tree()
         kept_elems: list = []
         for elem in elems:
             if elem.tag != "table":
@@ -297,7 +322,7 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
                 # Already registered with matching columns. Merge any rows from this install's
                 # .loc.sample(s) into the shared loc file.
                 self._merge_loc_sample_entries(existing, elem, loc_basename_to_source, tool_shed_repository)
-                if self._shed_config_has_matching_entry(table_name, elem):
+                if self._tree_has_matching_entry(shed_config_tree, table_name, elem):
                     # An identical <table> entry already exists in shed_tool_data_table_config.
                     # Don't write another one (it would just duplicate the shared loc reference).
                     continue

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -67,6 +67,22 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+
+def _ensure_trailing_newline(fh: BinaryIO) -> None:
+    """Ensure ``fh`` (open in r+b mode) ends with a newline.
+
+    Seeks to end-of-file; if the file is non-empty and the last byte isn't a newline,
+    writes one. Leaves the file position at end-of-file so subsequent appends produce
+    one row per line.
+    """
+    fh.seek(0, 2)
+    if fh.tell() == 0:
+        return
+    fh.seek(-1, 2)
+    if fh.read(1) not in (b"\n", b"\r"):
+        fh.write(b"\n")
+
+
 BUNDLE_INDEX_FILE_NAME = "_gx_data_bundle_index.json"
 DEFAULT_TABLE_TYPE = "tabular"
 
@@ -757,12 +773,7 @@ class TabularToolDataTable(ToolDataTable):
                     try:
                         if os.path.exists(filename):
                             data_table_fh = open(filename, "r+b")
-                            if os.stat(filename).st_size > 0:
-                                # ensure last existing line ends with new line
-                                data_table_fh.seek(-1, 2)  # last char in file
-                                last_char = data_table_fh.read(1)
-                                if last_char not in [b"\n", b"\r"]:
-                                    data_table_fh.write(b"\n")
+                            _ensure_trailing_newline(data_table_fh)
                         else:
                             data_table_fh = open(filename, "wb")
                     except OSError as e:
@@ -783,6 +794,9 @@ class TabularToolDataTable(ToolDataTable):
         (the table's primary key) against existing in-memory rows and the pending
         batch. Writes a single ``{comment_char} {attribution}`` line before the first
         new row. No-op if no rows survive the dedup.
+
+        Holds a ``FileLock`` for the duration of the append to serialize with
+        concurrent ``_add_entry`` calls (Data Manager row appends) on the same loc.
         """
         filename: Optional[str] = self.get_filename_for_source(None)
         if filename is None:
@@ -807,6 +821,12 @@ class TabularToolDataTable(ToolDataTable):
                 )
                 continue
             if existing_values is not None and fields[value_index] in existing_values:
+                log.debug(
+                    'Skipping duplicate entry for data table "%s" (value=%s): "%s"',
+                    self.name,
+                    fields[value_index],
+                    fields,
+                )
                 continue
             new_rows.append(fields)
             if existing_values is not None:
@@ -814,12 +834,13 @@ class TabularToolDataTable(ToolDataTable):
         if not new_rows:
             return self._loaded_content_version
         with FileLock(filename):
-            if os.path.exists(filename) and os.stat(filename).st_size > 0:
-                with open(filename, "rb+") as fh:
-                    fh.seek(-1, 2)
-                    if fh.read(1) not in (b"\n", b"\r"):
-                        fh.write(b"\n")
-            with open(filename, "ab") as fh:
+            fh: BinaryIO
+            if os.path.exists(filename):
+                fh = open(filename, "r+b")
+                _ensure_trailing_newline(fh)
+            else:
+                fh = open(filename, "wb")
+            with fh:
                 fh.write(f"{self.comment_char} {attribution}\n".encode())
                 for fields in new_rows:
                     fh.write(f"{self.separator.join(fields)}\n".encode())
@@ -1067,10 +1088,12 @@ class ToolDataTableManager(Dictifiable):
     ) -> None:
         """Raise if ``candidate_name`` is already registered with different columns."""
         existing = self.data_tables.get(candidate_name)
-        if existing is not None:
-            existing_columns = getattr(existing, "columns", None)
-            if existing_columns is not None and existing_columns != candidate_columns:
-                raise DataTableColumnMismatch(candidate_name, existing_columns, candidate_columns)
+        if (
+            isinstance(existing, TabularToolDataTable)
+            and existing.columns is not None
+            and existing.columns != candidate_columns
+        ):
+            raise DataTableColumnMismatch(candidate_name, existing.columns, candidate_columns)
 
     def to_dict(
         self, view: str = "collection", value_mapper: Optional[Dict[str, Callable]] = None

--- a/lib/tool_shed/test/base/testcase.py
+++ b/lib/tool_shed/test/base/testcase.py
@@ -1709,7 +1709,9 @@ class ShedTestCase(ShedApiTestCase):
                     ), f"The hard-coded Galaxy tool-data directory is missing for the {required_data_table_entry} entry."
                     assert os.path.exists(galaxy_tool_data_dir), "The Galaxy tool-data directory does not exist."
                     # Make sure the loc_file_name was correctly copied into the configured directory location.
-                    configured_file_location = os.path.join(self.tool_data_path, loc_file_name)
+                    # Shed-installed loc files now live under tool_data_path/shed/ to keep them
+                    # separate from admin-configured ones.
+                    configured_file_location = os.path.join(self.tool_data_path, "shed", loc_file_name)
                     assert os.path.isfile(
                         configured_file_location
                     ), f'The expected copied file "{configured_file_location}" is missing.'

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -80,10 +80,18 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
             ), f"Shed loc file should not land at tool_data_path root: {loc_file}"
         shed_conf = self._app.config.shed_tool_data_table_config
         if os.path.exists(shed_conf):
-            for table_elem in ET.parse(shed_conf).getroot().findall("table"):
+            tables = ET.parse(shed_conf).getroot().findall("table")
+            assert tables, f"Expected at least one <table> entry in {shed_conf} for non-DM install"
+            for table_elem in tables:
                 assert (
                     table_elem.find("tool_shed_repository") is None
                 ), f"Table {table_elem.get('name')!r} should not have a <tool_shed_repository> sub-element"
+                file_elem = table_elem.find("file")
+                assert file_elem is not None, f"Table {table_elem.get('name')!r} missing <file> entry"
+                file_path = file_elem.get("path", "")
+                assert (
+                    os.sep + "shed" + os.sep in file_path
+                ), f"Table {table_elem.get('name')!r} file path {file_path!r} should reference the shed/ subdir"
 
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]

--- a/test/unit/tool_shed/conftest.py
+++ b/test/unit/tool_shed/conftest.py
@@ -1,5 +1,14 @@
+import os
+from unittest import mock
+
 import pytest
 
+from galaxy.tool_shed.tools.data_table_manager import ShedToolDataTableManager
+from galaxy.tool_util.data import ToolDataTableManager
+from galaxy.util import (
+    parse_xml,
+    xml_to_string,
+)
 from tool_shed.webapp.model import (
     Repository,
     User,
@@ -11,6 +20,108 @@ from ._util import (
     TestToolShedApp,
     user_fixture,
 )
+
+SAMPLE_TABLE_CONF = """\
+<tables>
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+</tables>
+"""
+
+LOC_SAMPLE_CONTENT = "# all_fasta.loc sample\n"
+
+
+class _FakeTableRegistry(ToolDataTableManager):
+    """In-memory stand-in for ``ToolDataTableManager`` used by shed-install unit tests.
+
+    ``to_xml_file`` writes the supplied ``new_elems`` to the target so dedup checks
+    that re-read the file (e.g. ``_load_shed_config_tree``) round-trip correctly.
+    """
+
+    def __init__(self):
+        self.data_tables: dict = {}
+        self.to_xml_calls: list = []
+
+    def to_xml_file(self, shed_tool_data_table_config, new_elems=None, remove_elems=None):
+        self.to_xml_calls.append((shed_tool_data_table_config, new_elems))
+        existing_root = None
+        if os.path.exists(shed_tool_data_table_config):
+            try:
+                existing_root = parse_xml(shed_tool_data_table_config).getroot()
+            except Exception:
+                existing_root = None
+        with open(shed_tool_data_table_config, "wb") as fh:
+            fh.write(b'<?xml version="1.0"?>\n<tables>\n')
+            if existing_root is not None:
+                for child in existing_root:
+                    fh.write(xml_to_string(child).encode("utf-8"))
+                    fh.write(b"\n")
+            for elem in new_elems or []:
+                fh.write(xml_to_string(elem).encode("utf-8"))
+                fh.write(b"\n")
+            fh.write(b"</tables>\n")
+
+    def add_new_entries_from_config_file(
+        self, config_filename, tool_data_path, shed_tool_data_table_config, persist=False
+    ):
+        # Tests don't need to exercise the real loader; record the call and return empty.
+        return [], None
+
+
+def _write_file(path: str, contents: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(contents)
+
+
+@pytest.fixture
+def make_stdtm(tmp_path):
+    """Build a ``ShedToolDataTableManager`` against a ``tmp_path``-backed config.
+
+    Returns a callable ``factory()`` that yields:
+        ``(stdtm, repo, sample_files, captured, tool_data_path,
+            shed_tool_data_path, relative_target_dir)``
+    where ``captured["to_xml_calls"]`` lets the test observe shed-config writes.
+    """
+
+    def _factory():
+        repo_dir = str(tmp_path / "repo")
+        tool_data_path = str(tmp_path / "tool-data")
+        shed_tool_data_path = str(tmp_path / "shed_tool_data")
+        shed_tool_data_table_config = str(tmp_path / "shed_data_table_conf.xml")
+        relative_target_dir = "owner/name/abc"
+
+        os.makedirs(tool_data_path, exist_ok=True)
+        os.makedirs(os.path.join(shed_tool_data_path, relative_target_dir), exist_ok=True)
+        _write_file(os.path.join(repo_dir, "tool_data_table_conf.xml.sample"), SAMPLE_TABLE_CONF)
+        _write_file(os.path.join(repo_dir, "tool-data", "all_fasta.loc.sample"), LOC_SAMPLE_CONTENT)
+
+        app = mock.MagicMock(name="app")
+        app.config.tool_data_path = tool_data_path
+        app.config.shed_tool_data_path = shed_tool_data_path
+        app.config.shed_tool_data_table_config = shed_tool_data_table_config
+        registry = _FakeTableRegistry()
+        app.tool_data_tables = registry
+        captured = {"to_xml_calls": registry.to_xml_calls}
+
+        stdtm = ShedToolDataTableManager(app)
+
+        repo = mock.MagicMock(name="tool_shed_repository")
+        repo.name = "data_manager_fetch_genome_dbkeys_all_fasta"
+        repo.owner = "iuc"
+        repo.installed_changeset_revision = "abc"
+        repo.tool_shed = "tool-shed"
+        repo.get_tool_relative_path.return_value = (repo_dir, relative_target_dir)
+
+        sample_files = [
+            "tool_data_table_conf.xml.sample",
+            os.path.join("tool-data", "all_fasta.loc.sample"),
+        ]
+        return stdtm, repo, sample_files, captured, tool_data_path, shed_tool_data_path, relative_target_dir
+
+    return _factory
 
 
 @pytest.fixture

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -1,45 +1,20 @@
 """Unit tests for shed-side data table install behavior."""
 
+import logging
 import os
 from unittest import mock
 
 import pytest
 
 from galaxy.tool_shed.tools.data_table_manager import (
+    _parse_table_columns,
     DataTableColumnMismatch,
-    ShedToolDataTableManager,
 )
-from galaxy.tool_util.data import (
-    TabularToolDataTable,
-    ToolDataTableManager,
-)
+from galaxy.tool_util.data import TabularToolDataTable
 from galaxy.util import (
     Element,
     SubElement,
 )
-
-
-class _FakeTableRegistry(ToolDataTableManager):
-    def __init__(self):
-        self.data_tables: dict = {}
-        self.to_xml_calls: list = []
-
-    def to_xml_file(self, shed_tool_data_table_config, new_elems=None, remove_elems=None):
-        self.to_xml_calls.append((shed_tool_data_table_config, new_elems))
-        with open(shed_tool_data_table_config, "wb") as fh:
-            fh.write(b"<tables/>")
-
-
-SAMPLE_TABLE_CONF = """\
-<tables>
-    <table name="all_fasta" comment_char="#">
-        <columns>value, dbkey, name, path</columns>
-        <file path="tool-data/all_fasta.loc" />
-    </table>
-</tables>
-"""
-
-LOC_SAMPLE_CONTENT = "# all_fasta.loc sample\n"
 
 
 def _write(path: str, contents: str) -> None:
@@ -48,53 +23,26 @@ def _write(path: str, contents: str) -> None:
         fh.write(contents)
 
 
-def _make_stdtm(tmp_path):
-    repo_dir = str(tmp_path / "repo")
-    tool_data_path = str(tmp_path / "tool-data")
-    shed_tool_data_path = str(tmp_path / "shed_tool_data")
-    shed_tool_data_table_config = str(tmp_path / "shed_data_table_conf.xml")
-    relative_target_dir = "owner/name/abc"
-
-    os.makedirs(tool_data_path)
-    os.makedirs(os.path.join(shed_tool_data_path, relative_target_dir))
-    _write(os.path.join(repo_dir, "tool_data_table_conf.xml.sample"), SAMPLE_TABLE_CONF)
-    _write(os.path.join(repo_dir, "tool-data", "all_fasta.loc.sample"), LOC_SAMPLE_CONTENT)
-
-    app = mock.MagicMock(name="app")
-    app.config.tool_data_path = tool_data_path
-    app.config.shed_tool_data_path = shed_tool_data_path
-    app.config.shed_tool_data_table_config = shed_tool_data_table_config
-    registry = _FakeTableRegistry()
-    app.tool_data_tables = registry
-    captured = {"to_xml_calls": registry.to_xml_calls}
-
-    stdtm = ShedToolDataTableManager(app)
-
-    repo = mock.MagicMock(name="tool_shed_repository")
-    repo.name = "data_manager_fetch_genome_dbkeys_all_fasta"
-    repo.owner = "iuc"
-    repo.installed_changeset_revision = "abc"
-    repo.tool_shed = "tool-shed"
-    repo.get_tool_relative_path.return_value = (repo_dir, relative_target_dir)
-
-    sample_files = [
-        "tool_data_table_conf.xml.sample",
-        os.path.join("tool-data", "all_fasta.loc.sample"),
-    ]
-    return stdtm, repo, sample_files, captured, tool_data_path, shed_tool_data_path, relative_target_dir
-
-
-def _registered_table(columns, filenames=None, type_key="tabular"):
+def _registered_table(columns, filenames=None):
     existing = mock.MagicMock(spec=TabularToolDataTable)
     existing.columns = columns
     existing.filenames = filenames or {}
-    existing.type_key = type_key
     existing.parse_file_fields.return_value = []
     return existing
 
 
+def _registered_non_tabular(columns, filenames=None):
+    """Plain MagicMock with no spec so ``isinstance(mock, TabularToolDataTable)`` is
+    False — used to verify the isinstance gate in ``_merge_loc_sample_entries`` skips
+    non-tabular table types (e.g. refgenie)."""
+    existing = mock.MagicMock()
+    existing.columns = columns
+    existing.filenames = filenames or {}
+    return existing
+
+
 def _write_shed_config_with_entry(stdtm, table_name, file_path):
-    """Pre-populate ``shed_tool_data_table_config`` with a single ``<table>`` matching ``elem``."""
+    """Pre-populate ``shed_tool_data_table_config`` with a single ``<table>``."""
     shed_config = stdtm.app.config.shed_tool_data_table_config
     contents = f"""<?xml version="1.0"?>
 <tables>
@@ -108,8 +56,8 @@ def _write_shed_config_with_entry(stdtm, table_name, file_path):
         fh.write(contents)
 
 
-def test_loc_file_lands_under_shed_subdir_not_per_revision(tmp_path):
-    stdtm, repo, samples, captured, tool_data_path, shed_tool_data_path, _ = _make_stdtm(tmp_path)
+def test_loc_file_lands_under_shed_subdir_not_per_revision(make_stdtm):
+    stdtm, repo, samples, captured, tool_data_path, shed_tool_data_path, _ = make_stdtm()
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
 
     shared_loc = os.path.join(tool_data_path, "shed", "all_fasta.loc")
@@ -124,14 +72,11 @@ def test_loc_file_lands_under_shed_subdir_not_per_revision(tmp_path):
     file_elems = list(kept_elems[0].findall("file"))
     assert len(file_elems) == 1
     assert file_elems[0].get("path") == shared_loc
-    # New installs should not stamp a <tool_shed_repository> sub-element on the <table>:
-    # the loc-file location is deterministic and DMs on legacy installs fall through to
-    # the shared-no-repo_info match in get_filename_for_source.
     assert kept_elems[0].find("tool_shed_repository") is None
 
 
-def test_existing_loc_file_is_not_overwritten(tmp_path):
-    stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
+def test_existing_loc_file_is_not_overwritten(make_stdtm):
+    stdtm, repo, samples, _, tool_data_path, _, _ = make_stdtm()
     shared_loc = os.path.join(tool_data_path, "shed", "all_fasta.loc")
     os.makedirs(os.path.dirname(shared_loc), exist_ok=True)
     _write(shared_loc, "preexisting DM-populated content\n")
@@ -142,8 +87,8 @@ def test_existing_loc_file_is_not_overwritten(tmp_path):
         assert fh.read() == "preexisting DM-populated content\n"
 
 
-def test_column_mismatch_raises(tmp_path):
-    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+def test_column_mismatch_raises(make_stdtm):
+    stdtm, repo, samples, captured, _, _, _ = make_stdtm()
     stdtm.app.tool_data_tables.data_tables = {
         "all_fasta": _registered_table({"value": 0, "name": 1, "path": 2}),
     }
@@ -154,11 +99,11 @@ def test_column_mismatch_raises(tmp_path):
     assert not captured["to_xml_calls"]
 
 
-def test_column_match_first_install_writes_table_entry(tmp_path):
+def test_column_match_first_install_writes_table_entry(make_stdtm):
     """When a table is already registered in memory but has not yet been written to
     ``shed_tool_data_table_config``, we still write a (stamp-less) ``<table>`` entry so the
     shared loc file's association with the table survives reload."""
-    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     stdtm.app.tool_data_tables.data_tables = {
         "all_fasta": _registered_table(matching_columns),
@@ -173,10 +118,10 @@ def test_column_match_first_install_writes_table_entry(tmp_path):
     assert kept_elems[0].find("tool_shed_repository") is None
 
 
-def test_column_match_subsequent_install_dedupes_shed_config_entry(tmp_path):
+def test_column_match_subsequent_install_dedupes_shed_config_entry(make_stdtm):
     """If shed_tool_data_table_config already has a ``<table>`` with the same name and same
     ``<file path>``, don't write another one."""
-    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     stdtm.app.tool_data_tables.data_tables = {
         "all_fasta": _registered_table(matching_columns),
@@ -189,8 +134,26 @@ def test_column_match_subsequent_install_dedupes_shed_config_entry(tmp_path):
     assert not captured["to_xml_calls"]
 
 
-def test_column_match_with_column_elements_writes_entry(tmp_path):
-    stdtm, repo, _, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+def test_dedup_does_not_match_same_name_different_file_paths(make_stdtm):
+    """Same table name but different `<file path>` must NOT dedupe — the entries refer
+    to distinct loc files and both should be persisted."""
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    stdtm.app.tool_data_tables.data_tables = {
+        "all_fasta": _registered_table(matching_columns),
+    }
+    # Existing entry points to a completely different loc file.
+    _write_shed_config_with_entry(stdtm, "all_fasta", "/some/other/path/all_fasta.loc")
+
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
+    assert len(kept_elems) == 1, "Different file paths should not be deduped"
+    file_elem = kept_elems[0].find("file")
+    assert file_elem.get("path") == os.path.join(tool_data_path, "shed", "all_fasta.loc")
+
+
+def test_column_match_with_column_elements_writes_entry(make_stdtm):
+    stdtm, repo, _, captured, tool_data_path, _, _ = make_stdtm()
     column_form_conf = """\
 <tables>
     <table name="all_fasta" comment_char="#">
@@ -216,14 +179,13 @@ def test_column_match_with_column_elements_writes_entry(tmp_path):
     assert kept_elems[0].find("tool_shed_repository") is None
 
 
-def test_second_install_merges_loc_sample_rows_with_attribution(tmp_path):
-    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+def test_second_install_merges_loc_sample_rows_with_attribution(make_stdtm):
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     existing = _registered_table(matching_columns)
     incoming_rows = [["hg19", "hg19", "human (hg19)", "/data/hg19.fa"]]
     existing.parse_file_fields.return_value = incoming_rows
     stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
-    # Pre-populate shed config so kept_elems stays empty — we're testing the row-merge path.
     _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
@@ -238,8 +200,8 @@ def test_second_install_merges_loc_sample_rows_with_attribution(tmp_path):
     assert "abc" in attribution
 
 
-def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
-    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+def test_second_install_with_empty_loc_sample_does_not_append(make_stdtm):
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     existing = _registered_table(matching_columns)
     existing.parse_file_fields.return_value = []
@@ -253,25 +215,47 @@ def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
     existing.append_entries_with_attribution.assert_not_called()
 
 
-def test_merge_skipped_for_non_tabular_table_types(tmp_path):
-    """Refgenie-backed (and other non-tabular) tables don't get their .loc.sample parsed
-    during install — refgenie's ``parse_file_fields`` expects YAML, not a .loc, so calling
-    it on a ``.loc.sample`` is incorrect."""
-    stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
-    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
-    existing = _registered_table(matching_columns, type_key="refgenie")
+def test_non_tabular_table_skips_merge_and_dedup(make_stdtm):
+    """If the already-registered table isn't a ``TabularToolDataTable``, both the
+    ``.loc.sample`` merge and the shed-config dedup check are skipped — we write a
+    fresh ``<table>`` entry and never call the table's row-parsing APIs (which
+    would be wrong for non-tabular formats like refgenie's YAML)."""
+    stdtm, repo, samples, _, tool_data_path, _, _ = make_stdtm()
+    existing = _registered_non_tabular({"value": 0, "dbkey": 1, "name": 2, "path": 3})
     stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
     _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
-    assert kept_elems == []
+    assert len(kept_elems) == 1, "Expected a fresh <table> entry since dedup is skipped for non-tabular"
     existing.parse_file_fields.assert_not_called()
     existing.append_entries_with_attribution.assert_not_called()
 
 
-def test_parse_table_columns_aliases_name_to_value():
-    from galaxy.tool_shed.tools.data_table_manager import _parse_table_columns
+def test_merge_skips_rows_with_here_token(make_stdtm, caplog):
+    """Rows in a ``.loc.sample`` that reference ``${__HERE__}`` are dropped with a
+    warning: the shared loc lives under ``tool_data_path/shed/`` so a preserved
+    ``${__HERE__}`` would resolve to the wrong directory."""
+    stdtm, repo, samples, _, tool_data_path, _, _ = make_stdtm()
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    existing = _registered_table(matching_columns)
+    existing.parse_file_fields.return_value = [
+        ["hg19", "hg19", "Human", "${__HERE__}/hg19.fa"],
+        ["mm10", "mm10", "Mouse", "/abs/path/mm10.fa"],
+    ]
+    stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+    _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
+    with caplog.at_level(logging.WARNING, logger="galaxy.tool_shed.tools.data_table_manager"):
+        stdtm.install_tool_data_tables(repo, samples)
+
+    # The HERE row was dropped; the absolute-path row was appended.
+    existing.append_entries_with_attribution.assert_called_once()
+    appended = existing.append_entries_with_attribution.call_args.args[0]
+    assert appended == [["mm10", "mm10", "Mouse", "/abs/path/mm10.fa"]]
+    assert any("__HERE__" in rec.message for rec in caplog.records)
+
+
+def test_parse_table_columns_aliases_name_to_value():
     elem = Element("table")
     cols = SubElement(elem, "columns")
     cols.text = "value, path"

--- a/test/unit/tool_shed/test_install_manager.py
+++ b/test/unit/tool_shed/test_install_manager.py
@@ -1,5 +1,16 @@
-"""Unit tests for install-time data table registration gating."""
+"""Unit tests for install-time data table registration.
 
+These exercise ``InstallRepositoryManager.__handle_repository_contents`` with a real
+``ShedToolDataTableManager`` (built against a tmp_path-backed config via the
+``make_stdtm`` fixture in ``conftest.py``). Only out-of-scope dependencies
+(``InstalledRepositoryMetadataManager``, ``DataManagerHandler``, etc.) are mocked.
+
+Earlier revisions of this test mocked ``ShedToolDataTableManager`` itself and
+asserted ``assert_called_once`` against the mock — that meant the very unit under
+test was a mock and the test would pass even if the install gating were inverted.
+"""
+
+import os
 from typing import (
     Any,
 )
@@ -10,36 +21,38 @@ from galaxy.tool_shed.galaxy_install import install_manager
 INSTALL_MANAGER_MODULE = "galaxy.tool_shed.galaxy_install.install_manager"
 
 
-def _make_install_repository_manager():
-    app = mock.MagicMock(name="app")
-    app.install_model.context = mock.MagicMock(name="session")
-    register_mock = mock.MagicMock(name="add_new_entries_from_config_file")
-    app.tool_data_tables.add_new_entries_from_config_file = register_mock
+def _build_irm(app):
+    """Build a real ``InstallRepositoryManager`` wired to the fixture-built ``app``."""
     irm = install_manager.InstallRepositoryManager.__new__(install_manager.InstallRepositoryManager)
     irm.app = app
     irm.install_model = app.install_model
+    # `context` is a read-only property on the real ModelMapping; on this MagicMock
+    # stand-in it just needs to exist as a writable attribute so the `session.add(...);
+    # session.commit()` calls in __handle_repository_contents land on the mock.
+    irm.install_model.context = mock.MagicMock(name="session")  # type: ignore[misc]
     irm.tpm = mock.MagicMock(name="tpm")
-    return irm, register_mock
+    return irm
 
 
-def _invoke_handle(irm, metadata_dict: dict[str, Any], repository_tools_tups: list[Any]):
+def _invoke_handle(
+    irm,
+    repo,
+    tool_path: str,
+    metadata_dict: dict[str, Any],
+    repository_tools_tups: list[Any],
+):
+    """Invoke the private ``__handle_repository_contents`` with the bare minimum of
+    external dependencies stubbed out. The real ``ShedToolDataTableManager`` is
+    NOT patched — we want to observe its on-disk effects."""
     irmm_instance = mock.MagicMock(name="irmm_instance")
     irmm_instance.get_metadata_dict.return_value = metadata_dict
     irmm_instance.get_repository_tools_tups.return_value = repository_tools_tups
 
-    stdtm_instance = mock.MagicMock(name="stdtm_instance")
-    stdtm_instance.get_tool_index_sample_files.return_value = []
-    stdtm_instance.install_tool_data_tables.return_value = (
-        "/dev/null/tool_data_table_conf.xml",
-        [object()],
-    )
-    stdtm_instance.handle_missing_data_table_entry.side_effect = lambda *_a, **_k: repository_tools_tups
-
     patches = [
         mock.patch(f"{INSTALL_MANAGER_MODULE}.InstalledRepositoryMetadataManager", return_value=irmm_instance),
-        mock.patch(f"{INSTALL_MANAGER_MODULE}.ShedToolDataTableManager", return_value=stdtm_instance),
         mock.patch(
-            f"{INSTALL_MANAGER_MODULE}.repository_util.get_tool_shed_status_for_installed_repository", return_value=None
+            f"{INSTALL_MANAGER_MODULE}.repository_util.get_tool_shed_status_for_installed_repository",
+            return_value=None,
         ),
         mock.patch(f"{INSTALL_MANAGER_MODULE}.tool_util.copy_sample_files"),
         mock.patch(
@@ -51,14 +64,11 @@ def _invoke_handle(irm, metadata_dict: dict[str, Any], repository_tools_tups: li
     for p in patches:
         p.start()
     try:
-        repo = mock.MagicMock(name="tool_shed_repository")
-        repo.changeset_revision = "abc"
-        repo.installed_changeset_revision = "abc"
         irm._InstallRepositoryManager__handle_repository_contents(
             tool_shed_repository=repo,
-            tool_path="/tmp/tool_path",
+            tool_path=tool_path,
             repository_clone_url="http://tool-shed/repos/owner/name",
-            relative_install_dir="owner/name/abc",
+            relative_install_dir="",  # repo dir is `tool_path` already
             tool_shed="tool-shed",
             tool_section=None,
             shed_tool_conf=None,
@@ -66,44 +76,98 @@ def _invoke_handle(irm, metadata_dict: dict[str, Any], repository_tools_tups: li
     finally:
         for p in patches:
             p.stop()
-    return stdtm_instance
 
 
-def test_non_data_manager_repo_registers_sample_files():
-    irm, register_mock = _make_install_repository_manager()
-    stdtm_instance = _invoke_handle(irm, {"sample_files": ["foo.loc.sample"]}, [])
-    stdtm_instance.install_tool_data_tables.assert_called_once()
-    register_mock.assert_called_once()
+def test_non_data_manager_install_writes_loc_file_under_shed(make_stdtm):
+    """A non-DM repo with a `.loc.sample` results in a shared loc file under
+    ``tool_data_path/shed/`` and a ``<table>`` entry in the shed config."""
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
+    irm = _build_irm(stdtm.app)
+
+    metadata = {"sample_files": samples, "tools": [{"id": "t"}]}
+    tool_stub = mock.MagicMock()
+    tool_stub.params_with_missing_data_table_entry = []
+    _invoke_handle(
+        irm,
+        repo,
+        tool_path=repo.get_tool_relative_path.return_value[0],
+        metadata_dict=metadata,
+        repository_tools_tups=[("p", "guid", tool_stub)],
+    )
+
+    assert os.path.exists(os.path.join(tool_data_path, "shed", "all_fasta.loc"))
+    # `to_xml_file` was invoked with the new <table> entry.
+    assert captured["to_xml_calls"], "Expected stdtm.to_xml_file to be called on first install"
 
 
-def test_data_manager_repo_registers_sample_files():
-    irm, register_mock = _make_install_repository_manager()
+def test_data_manager_install_also_writes_loc_file_under_shed(make_stdtm):
+    """Same on-disk effect for a DM repo (the `data_manager` key in metadata only
+    drives ``DataManagerHandler``; data-table registration goes through the same path)."""
+    stdtm, repo, samples, captured, tool_data_path, _, _ = make_stdtm()
+    irm = _build_irm(stdtm.app)
+
     metadata = {
-        "sample_files": ["foo.loc.sample"],
+        "sample_files": samples,
         "tools": [{"id": "t"}],
         "data_manager": {"data_managers": {}},
     }
-    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
-    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
-    stdtm_instance.install_tool_data_tables.assert_called_once()
-    register_mock.assert_called_once()
+    tool_stub = mock.MagicMock()
+    tool_stub.params_with_missing_data_table_entry = []
+    _invoke_handle(
+        irm,
+        repo,
+        tool_path=repo.get_tool_relative_path.return_value[0],
+        metadata_dict=metadata,
+        repository_tools_tups=[("p", "guid", tool_stub)],
+    )
+
+    assert os.path.exists(os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
 
-def test_non_data_manager_repo_skips_handle_missing_data_table_entry():
-    irm, _ = _make_install_repository_manager()
-    metadata = {"tools": [{"id": "t"}], "sample_files": []}
-    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
-    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
-    stdtm_instance.handle_missing_data_table_entry.assert_not_called()
+def test_handle_missing_data_table_entry_runs_for_non_dm(make_stdtm):
+    """After dropping the `is_data_manager` gate, non-DM repos with a tool whose
+    params reference an unregistered data table also get the fallback recovery
+    that loads the repo's ``tool_data_table_conf.xml.sample``.
+
+    Mutation check: re-introducing the gate causes this test to fail because the
+    in-memory tables are no longer reset (no recovery was attempted)."""
+    stdtm, repo, samples, captured, _, _, _ = make_stdtm()
+    irm = _build_irm(stdtm.app)
+    repo_dir = repo.get_tool_relative_path.return_value[0]
+
+    # Seed an existing table in the registry so we can observe the reset wipe it.
+    stdtm.app.tool_data_tables.data_tables = {"sentinel_before_reset": object()}
+
+    tool_stub = mock.MagicMock()
+    tool_stub.params_with_missing_data_table_entry = [mock.MagicMock()]  # signals "table missing"
+
+    metadata = {"sample_files": [], "tools": [{"id": "t"}]}  # no install_tool_data_tables run
+    _invoke_handle(
+        irm, repo, tool_path=repo_dir, metadata_dict=metadata, repository_tools_tups=[("p", "guid", tool_stub)]
+    )
+
+    # The fallback called `reset_tool_data_tables()`, which wipes `data_tables`.
+    assert (
+        stdtm.app.tool_data_tables.data_tables == {}
+    ), "Expected handle_missing_data_table_entry to run and reset the in-memory tables"
 
 
-def test_data_manager_repo_invokes_handle_missing_data_table_entry():
-    irm, _ = _make_install_repository_manager()
-    metadata = {
-        "tools": [{"id": "t"}],
-        "sample_files": [],
-        "data_manager": {"data_managers": {}},
-    }
-    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
-    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
-    stdtm_instance.handle_missing_data_table_entry.assert_called_once()
+def test_handle_missing_data_table_entry_no_op_when_no_missing(make_stdtm):
+    """The fallback only fires when a tool has `params_with_missing_data_table_entry`;
+    otherwise the registry is left untouched."""
+    stdtm, repo, samples, captured, _, _, _ = make_stdtm()
+    irm = _build_irm(stdtm.app)
+    repo_dir = repo.get_tool_relative_path.return_value[0]
+
+    sentinel = object()
+    stdtm.app.tool_data_tables.data_tables = {"sentinel": sentinel}
+
+    tool_stub = mock.MagicMock()
+    tool_stub.params_with_missing_data_table_entry = []
+
+    metadata = {"sample_files": [], "tools": [{"id": "t"}]}
+    _invoke_handle(
+        irm, repo, tool_path=repo_dir, metadata_dict=metadata, repository_tools_tups=[("p", "guid", tool_stub)]
+    )
+
+    assert stdtm.app.tool_data_tables.data_tables["sentinel"] is sentinel


### PR DESCRIPTION
verify_installed_repository_data_table_entries was looking for the installed loc file at tool_data_path root, but shed-installed loc files now live under tool_data_path/shed/. Also collapse a black-fmt-flagged multi-line copy_sample_files call onto one line.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
